### PR TITLE
Set healthcheck defaults at "low" setting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,12 +27,12 @@ data "template_file" "vcl_backend" {
             $${ssl_ca_cert_section}
             .ssl_check_cert = $${ssl_check_cert};
             .probe = {
-                .request = "HEAD /internal/healthcheck HTTP/1.1" "Connection: close";
+                .request = "HEAD $${healthcheck_path} HTTP/1.1" "Connection: close";
                 .window = $${probe_window};
                 .threshold = $${probe_threshold};
                 .timeout = $${probe_timeout};
                 .initial = $${probe_initial};
-                .dummy = true;
+                .interval = $${probe_interval};
             }
         }
 END
@@ -48,17 +48,19 @@ END
     backend_port          = "${var.backend_port}"
     backend_host          = "${var.backend_host}"
 
-    ssl_ca_cert_section = "${
+    ssl_ca_cert_section   = "${
             var.ssl_ca_cert == "" ? "" : join("", list("
                 .ssl_ca_cert = {\"", var.ssl_ca_cert, "\"};
             "))
         }"
 
-    ssl_check_cert = "${var.ssl_check_cert}"
+    ssl_check_cert        = "${var.ssl_check_cert}"
 
-    probe_window    = "${var.probe_window}"
-    probe_threshold = "${var.probe_threshold}"
-    probe_timeout   = "${var.probe_timeout}"
-    probe_initial   = "${var.probe_initial}"
+    probe_window          = "${var.probe_window}"
+    probe_threshold       = "${var.probe_threshold}"
+    probe_timeout         = "${var.probe_timeout}"
+    probe_interval        = "${var.probe_interval}"
+    probe_initial         = "${var.probe_initial}"
+    healthcheck_path      = "${var.healthcheck_path}"
   }
 }

--- a/test/test_config_generation.py
+++ b/test/test_config_generation.py
@@ -59,11 +59,11 @@ class TestConfigGeneration(unittest.TestCase):
                     \.ssl_check_cert = always ;
                     \.probe = \{
                         \.request = "HEAD \s /internal/healthcheck HTTP/1.1" \s "Connection: \s close";
-                        \.window = 5 ;
+                        \.window = 2 ;
                         \.threshold = 1 ;
-                        \.timeout = 2s ;
-                        \.initial = 5 ;
-                        \.dummy = true ;
+                        \.timeout = 5s ;
+                        \.initial = 1 ;
+                        \.interval = 60s ;
                     \}
                 \}
             '''), re.X)
@@ -88,11 +88,11 @@ class TestConfigGeneration(unittest.TestCase):
                     \.ssl_check_cert = always ;
                     \.probe = \{
                         \.request = "HEAD \s /internal/healthcheck HTTP/1.1" \s "Connection: \s close";
-                        \.window = 5 ;
+                        \.window = 2 ;
                         \.threshold = 1 ;
-                        \.timeout = 2s ;
-                        \.initial = 5 ;
-                        \.dummy = true ;
+                        \.timeout = 5s ;
+                        \.initial = 1 ;
+                        \.interval = 60s ;
                     \}
                 \}
             '''), re.X)
@@ -116,11 +116,11 @@ class TestConfigGeneration(unittest.TestCase):
                     \.ssl_check_cert = never ;
                     \.probe = \{
                         \.request = "HEAD \s /internal/healthcheck HTTP/1.1" \s "Connection: \s close";
-                        \.window = 5 ;
+                        \.window = 2 ;
                         \.threshold = 1 ;
-                        \.timeout = 2s ;
-                        \.initial = 5 ;
-                        \.dummy = true ;
+                        \.timeout = 5s ;
+                        \.initial = 1 ;
+                        \.interval = 60s ;
                     \}
                 \}
             '''), re.X)

--- a/variables.tf
+++ b/variables.tf
@@ -59,26 +59,38 @@ variable "ssl_check_cert" {
   default     = "always"
 }
 
-variable "probe_window" {
-  description = ""
-  type        = "string"
-  default     = "5"
-}
-
 variable "probe_threshold" {
-  description = ""
+  description = "Along with the probe_window, the number of successes per total number health checks. For example, specifying 1/2 means 1 out of 2 checks must pass to be reported as healthy."
   type        = "string"
   default     = "1"
 }
 
-variable "probe_timeout" {
-  description = ""
+variable "probe_window" {
+  description = "See the description for probe_threshold above. Default is based on Fastly's \"Low\" option - see https://docs.fastly.com/guides/basic-configuration/health-check-frequency."
   type        = "string"
-  default     = "2s"
+  default     = "2"
 }
 
 variable "probe_initial" {
-  description = ""
+  description = "The number of requests to assume as passing on deploy. Default is based on Fastly's \"Low\" option - see https://docs.fastly.com/guides/basic-configuration/health-check-frequency."
   type        = "string"
-  default     = "5"
+  default     = "1"
+}
+
+variable "probe_interval" {
+  description = "The period of time for the requests to run. Default is based on Fastly's \"Low\" option - see https://docs.fastly.com/guides/basic-configuration/health-check-frequency."
+  type        = "string"
+  default     = "60s"
+}
+
+variable "probe_timeout" {
+  description = "The wait time until request is considered failed. Default is based on Fastly's \"Low\" option - see https://docs.fastly.com/guides/basic-configuration/health-check-frequency."
+  type        = "string"
+  default     = "5s"
+}
+
+variable "healthcheck_path" {
+  description = "Path to visit on your origins when performing the check."
+  type        = "string"
+  default     = "/internal/healthcheck"
 }


### PR DESCRIPTION
Change the healthcheck defaults to match Fastly's "low" preset - see:

https://docs.fastly.com/guides/basic-configuration/health-check-frequency.