### PR TITLE
Disable probe by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ data "template_file" "vcl_backend" {
                 .timeout = $${probe_timeout};
                 .initial = $${probe_initial};
                 .interval = $${probe_interval};
+                $${dummy}
             }
         }
 END
@@ -49,10 +50,10 @@ END
     backend_host          = "${var.backend_host}"
 
     ssl_ca_cert_section   = "${
-            var.ssl_ca_cert == "" ? "" : join("", list("
-                .ssl_ca_cert = {\"", var.ssl_ca_cert, "\"};
-            "))
-        }"
+        var.ssl_ca_cert == "" ? "" : join("", list("
+            .ssl_ca_cert = {\"", var.ssl_ca_cert, "\"};
+        "))
+    }"
 
     ssl_check_cert        = "${var.ssl_check_cert}"
 
@@ -62,5 +63,6 @@ END
     probe_interval        = "${var.probe_interval}"
     probe_initial         = "${var.probe_initial}"
     healthcheck_path      = "${var.healthcheck_path}"
+    dummy                 = "${var.probe_enabled ? "" : ".dummy = true;"}"
   }
 }

--- a/test/test_config_generation.py
+++ b/test/test_config_generation.py
@@ -64,6 +64,7 @@ class TestConfigGeneration(unittest.TestCase):
                         \.timeout = 5s ;
                         \.initial = 1 ;
                         \.interval = 60s ;
+                        \.dummy = true ;
                     \}
                 \}
             '''), re.X)
@@ -93,6 +94,7 @@ class TestConfigGeneration(unittest.TestCase):
                         \.timeout = 5s ;
                         \.initial = 1 ;
                         \.interval = 60s ;
+                        \.dummy = true ;
                     \}
                 \}
             '''), re.X)
@@ -121,6 +123,7 @@ class TestConfigGeneration(unittest.TestCase):
                         \.timeout = 5s ;
                         \.initial = 1 ;
                         \.interval = 60s ;
+                        \.dummy = true ;
                     \}
                 \}
             '''), re.X)

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "ssl_check_cert" {
   default     = "always"
 }
 
+variable "probe_enabled" {
+  description = "Whether the backend should be probed."
+  type        = "string"
+  default     = "false"
+}
+
 variable "probe_threshold" {
   description = "Along with the probe_window, the number of successes per total number health checks. For example, specifying 1/2 means 1 out of 2 checks must pass to be reported as healthy."
   type        = "string"


### PR DESCRIPTION
This reinstates `.dummy = true;` since it seems like this disables the
probe, which makes more sense for our backend. We _think_ this will
still work with a dynamic (i.e. DNS based) backend, but will check.

JIRA: PLAT-345