### PR TITLE
Complete vcl_recv when a match is found

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,11 @@ data "template_file" "vcl_recv" {
   template = <<END
         if ($${vcl_recv_condition}) {
             set req.backend = $${backend_name};
+            if (req.request == "HEAD" || req.request == "GET" || req.request == "FASTLYPURGE") {
+                return(lookup);
+            else {
+                return(pass);
+            }
         }
 END
 

--- a/test/test_config_generation.py
+++ b/test/test_config_generation.py
@@ -36,11 +36,11 @@ class TestConfigGeneration(unittest.TestCase):
                 defaults_vcl_recv =
                 if \( test-cond \) \{
                     set req\.backend \= test-backend\;
-                    if (req.request == "HEAD" || req.request == "GET" || req.request == "FASTLYPURGE") {
-                        return(lookup);
-                    else {
-                        return(pass);
-                    }
+                    if \(req\.request == "HEAD" \|\| req\.request == "GET" \|\| req\.request == "FASTLYPURGE"\) \{
+                        return\(lookup\);
+                    else \{
+                        return\(pass\);
+                    \}
                 \}
             '''), re.X)
         )

--- a/test/test_config_generation.py
+++ b/test/test_config_generation.py
@@ -36,6 +36,11 @@ class TestConfigGeneration(unittest.TestCase):
                 defaults_vcl_recv =
                 if \( test-cond \) \{
                     set req\.backend \= test-backend\;
+                    if (req.request == "HEAD" || req.request == "GET" || req.request == "FASTLYPURGE") {
+                        return(lookup);
+                    else {
+                        return(pass);
+                    }
                 \}
             '''), re.X)
         )


### PR DESCRIPTION
This change stops all rules being evaluated, which has the effect of
putting defaults later the way it works with an ALB (meets my
expectation better at least).