### PR TITLE
Make code shield-friendly

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,7 @@
 data "template_file" "vcl_recv" {
   template = <<END
-        if ($${vcl_recv_condition}) {
+        if (req.backend == F_default_backend && ($${vcl_recv_condition})) {
             set req.backend = $${backend_name};
-            if (req.request == "HEAD" || req.request == "GET" || req.request == "FASTLYPURGE") {
-                return(lookup);
-            } else {
-                return(pass);
-            }
         }
 END
 

--- a/test/test_config_generation.py
+++ b/test/test_config_generation.py
@@ -34,13 +34,8 @@ class TestConfigGeneration(unittest.TestCase):
             self.output,
             re.compile(optional_whitespace(r'''
                 defaults_vcl_recv =
-                if \( test-cond \) \{
+                if \( req.backend == F_default_backend && \( test-cond \) \) \{
                     set req\.backend \= test-backend\;
-                    if \(req\.request == "HEAD" \|\| req\.request == "GET" \|\| req\.request == "FASTLYPURGE"\) \{
-                        return\(lookup\);
-                    \} else \{
-                        return\(pass\);
-                    \}
                 \}
             '''), re.X)
         )


### PR DESCRIPTION
The conditional part is placed at the end of vcl_recv, immediately after
the code handling shielding. The shielding code replaces the default
backend with a special backend for the shield pop if and only if the pop
is not the shield pop. Therefore if the backend is still the default
(and not this special backend), then either shielding is off or we are
already running in the shield pop. Also, since we override the backend
there is no need for the early return.

JIRA: PLAT-1427