### PR TITLE
Use the same domain for SNI

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ data "template_file" "vcl_backend" {
             .host = "$${backend_host}";
 
             .ssl = true;
+            .ssl_sni_hostname = "$${ssl_cert_hostname}";
             .ssl_cert_hostname = "$${ssl_cert_hostname}";
             $${ssl_ca_cert_section}
             .ssl_check_cert = $${ssl_check_cert};

--- a/test/test_config_generation.py
+++ b/test/test_config_generation.py
@@ -55,6 +55,7 @@ class TestConfigGeneration(unittest.TestCase):
                     \.port = "443" ;
                     \.host = "test-host" ;
                     \.ssl = true ;
+                    \.ssl_sni_hostname = "test-host" ;
                     \.ssl_cert_hostname = "test-host" ;
                     \.ssl_check_cert = always ;
                     \.probe = \{
@@ -84,6 +85,7 @@ class TestConfigGeneration(unittest.TestCase):
                     \.port = "443" ;
                     \.host = "dummy-host" ;
                     \.ssl = true ;
+                    \.ssl_sni_hostname = "dummy-host" ;
                     \.ssl_cert_hostname = "dummy-host" ;
                     \.ssl_ca_cert = \{"line 1\nline 2\nline 3\n"\} ;
                     \.ssl_check_cert = always ;
@@ -114,6 +116,7 @@ class TestConfigGeneration(unittest.TestCase):
                     \.port = "443" ;
                     \.host = "dummy-host" ;
                     \.ssl = true ;
+                    \.ssl_sni_hostname = "dummy-host" ;
                     \.ssl_cert_hostname = "dummy-host" ;
                     \.ssl_check_cert = never ;
                     \.probe = \{


### PR DESCRIPTION
So the backend can select the right cert.