### PR TITLE
Add explicit SNI variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ data "template_file" "vcl_backend" {
             .host = "$${backend_host}";
 
             .ssl = true;
-            .ssl_sni_hostname = "$${ssl_cert_hostname}";
+            $${ssl_sni_hostname_section}
             .ssl_cert_hostname = "$${ssl_cert_hostname}";
             $${ssl_ca_cert_section}
             .ssl_check_cert = $${ssl_check_cert};
@@ -49,6 +49,12 @@ END
     max_connections       = "${var.max_connections}"
     backend_port          = "${var.backend_port}"
     backend_host          = "${var.backend_host}"
+
+    ssl_sni_hostname_section = "${
+        var.ssl_sni_hostname == "" ? "" : join("", list("
+            .ssl_sni_hostname = \"", var.ssl_sni_hostname, "\";
+        "))
+    }"
 
     ssl_ca_cert_section   = "${
         var.ssl_ca_cert == "" ? "" : join("", list("

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -51,3 +51,19 @@ module "ssl_check_cert" {
 output "ssl_check_cert_vcl_backend" {
   value = "${module.ssl_check_cert.vcl_backend}"
 }
+
+# ssl_sni_hostname
+
+variable "ssl_sni_hostname" {}
+
+module "ssl_sni_hostname" {
+  source = "../.."
+  vcl_recv_condition = "dummy-vcl-recv-condition"
+  backend_name = "dummy-backend"
+  backend_host = "dummy-host"
+  ssl_sni_hostname  = "${var.ssl_sni_hostname}"
+}
+
+output "ssl_sni_hostname_vcl_backend" {
+  value = "${module.ssl_sni_hostname.vcl_backend}"
+}

--- a/test/test_config_generation.py
+++ b/test/test_config_generation.py
@@ -25,6 +25,7 @@ class TestConfigGeneration(unittest.TestCase):
             '-var', 'defaults_backend_host=test-host',
             '-var', 'ssl_ca_cert=line 1\nline 2\nline 3\n',
             '-var', 'ssl_check_cert=never',
+            '-var', 'ssl_sni_hostname=test-sni.hostname',
             'test/infra'
         ]).decode('utf-8')
 
@@ -55,7 +56,6 @@ class TestConfigGeneration(unittest.TestCase):
                     \.port = "443" ;
                     \.host = "test-host" ;
                     \.ssl = true ;
-                    \.ssl_sni_hostname = "test-host" ;
                     \.ssl_cert_hostname = "test-host" ;
                     \.ssl_check_cert = always ;
                     \.probe = \{
@@ -85,7 +85,6 @@ class TestConfigGeneration(unittest.TestCase):
                     \.port = "443" ;
                     \.host = "dummy-host" ;
                     \.ssl = true ;
-                    \.ssl_sni_hostname = "dummy-host" ;
                     \.ssl_cert_hostname = "dummy-host" ;
                     \.ssl_ca_cert = \{"line 1\nline 2\nline 3\n"\} ;
                     \.ssl_check_cert = always ;
@@ -116,9 +115,38 @@ class TestConfigGeneration(unittest.TestCase):
                     \.port = "443" ;
                     \.host = "dummy-host" ;
                     \.ssl = true ;
-                    \.ssl_sni_hostname = "dummy-host" ;
                     \.ssl_cert_hostname = "dummy-host" ;
                     \.ssl_check_cert = never ;
+                    \.probe = \{
+                        \.request = "HEAD \s /internal/healthcheck HTTP/1.1" \s "Connection: \s close";
+                        \.window = 2 ;
+                        \.threshold = 1 ;
+                        \.timeout = 5s ;
+                        \.initial = 1 ;
+                        \.interval = 60s ;
+                        \.dummy = true ;
+                    \}
+                \}
+            '''), re.X)
+        )
+
+    def test_ssl_sni_hostname(self):
+        self.assertRegexpMatches(
+            self.output,
+            re.compile(optional_whitespace(r'''
+                ssl_sni_hostname_vcl_backend =
+                backend dummy-backend \{
+                    \.connect_timeout = 5s ;
+                    \.dynamic = true ;
+                    \.first_byte_timeout = 20s ;
+                    \.between_bytes_timeout = 20s ;
+                    \.max_connections = 1000 ;
+                    \.port = "443" ;
+                    \.host = "dummy-host" ;
+                    \.ssl = true ;
+                    \.ssl_sni_hostname = "test-sni.hostname" ;
+                    \.ssl_cert_hostname = "dummy-host" ;
+                    \.ssl_check_cert = always ;
                     \.probe = \{
                         \.request = "HEAD \s /internal/healthcheck HTTP/1.1" \s "Connection: \s close";
                         \.window = 2 ;

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "ssl_cert_hostname" {
   default     = ""
 }
 
+variable "ssl_sni_hostname" {
+  description = "Value to send to backend in SNI - default is blank, meaning no hostname is sent (generally should either be ssl_cert_hostname or the host the user is requesting)."
+  type        = "string"
+  default     = ""
+}
+
 variable "ssl_ca_cert" {
   description = "SSL CA certificate in PEM format to validate the backend cert against"
   default     = ""


### PR DESCRIPTION
The n3rd backends don't work using the backend name as the SNI hostname
since they are IP addresses. Instead make it explicit so backends have
to choose to use SNI and what hostname to use.